### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "An unordered data structure with immediate insertion, removal and
 version = "2.0.1"
 edition = "2021"
 license = "MIT"
-repository = "https://www.github.com/DragonGamesStudios/data_registry"
+repository = "https://github.com/DragonGamesStudios/data_registry"
 
 [dependencies]
 serde = { version = "1.0.216", optional = true, default-features = false, features = ["alloc"] }


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96